### PR TITLE
Hot reload improvements

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -4,7 +4,7 @@ root = "."
 tmp_dir = "tmp"
 
 [build]
-exclude_dir = ["cypress", "docker", "logs", "pacts", "prism", "tmp", "web/assets", "web/static", "node_modules"]
+exclude_dir = ["cypress", "docker", "tmp", "web/assets", "web/static", "node_modules", "json-server"]
 cmd = "go build -gcflags='all=-N -l' -o ./tmp/main ."
 bin = "tmp/main"
 full_bin = "dlv exec --accept-multiclient --log --headless --continue --listen :2345 --api-version 2 ./tmp/main"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 node_modules
-node_modules
 cypress/screenshots
 cypress/videos
+tmp
+/main
+web/static


### PR DESCRIPTION
Docker compose stack for local development was inadvertently using local built assets instead of the containers. Also reduces the scope of watched files for hot-reloading