### PR TITLE
SW-5908 add unit tests as suggested and tidy up read me

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 - [docker-compose](https://docs.docker.com/compose/install/) (>= 1.27.4)
 
 #### Installing dependencies locally: 
+
 - `yarn install`
 - `go mod download`
--------------------------------------------------------------------
+- 
+---
 
 ## Local development
 
@@ -41,13 +43,16 @@ Alternatively to set it up not using Docker use below. This hosts it on `localho
 
 `docker-compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml up --build`
 
-`yarn and yarn cypress`   
+`yarn && yarn cypress`   
+
 -------------------------------------------------------------------
-## Run the Pact tests in more detail
+## Run the unit/functional tests
 
 test sirius files: `yarn test-sirius`
 
 test server files: `yarn test-server`
+
+Run all Go tests:  `go test ./...`
 
 -------------------------------------------------------------------
 ## Noted issues:

--- a/internal/sirius/get_applied_filters_test.go
+++ b/internal/sirius/get_applied_filters_test.go
@@ -1,0 +1,415 @@
+package sirius
+
+import (
+	"github.com/ministryofjustice/opg-sirius-workflow/internal/mocks"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetAppliedFiltersSingleTaskFilterSelectedReturned(t *testing.T) {
+
+	mockClient := &mocks.MockClient{}
+	client, _ := NewClient(mockClient, "http://localhost:3000")
+
+	apiTaskTypes := []ApiTaskTypes{
+		{
+			Handle:     "CWGN",
+			Incomplete: "Casework - General",
+			Complete:   "Casework - General",
+			User:       true,
+			Category:   "supervision",
+			IsSelected: true,
+		},
+		{
+			Handle:     "ORAL",
+			Incomplete: "Order - Allocate to team",
+			Complete:   "Order - Allocate to team",
+			User:       true,
+			Category:   "supervision",
+			IsSelected: false,
+		},
+	}
+
+	teamCollection := []ReturnedTeamCollection{
+		{
+			Id:             12,
+			Name:           "Lay Team 1 - (Supervision)",
+			Type:           "Supervision",
+			TypeLabel:      "Only",
+			IsTeamSelected: false,
+		},
+		{
+			Id:             13,
+			Name:           "Allocations Team",
+			Type:           "Supervision",
+			TypeLabel:      "Only",
+			IsTeamSelected: false,
+		},
+	}
+
+	assigneeTeam := AssigneesTeam{
+		Id:   12,
+		Name: "Lay Team 1 - (Supervision)",
+		Members: []AssigneeTeamMembers{
+			{
+				TeamMembersId:          1,
+				TeamMembersName:        "Test One",
+				TeamMembersDisplayName: "Test One",
+				IsSelected:             false,
+			},
+			{
+				TeamMembersId:          2,
+				TeamMembersName:        "Test Two",
+				TeamMembersDisplayName: "Test Two",
+				IsSelected:             false,
+			},
+		},
+	}
+
+	expectedFilter := []string{
+		"Casework - General",
+	}
+
+	appliedFilters := client.GetAppliedFilters(12, apiTaskTypes, teamCollection, assigneeTeam)
+
+	assert.Equal(t, expectedFilter, appliedFilters)
+	assert.Equal(t, 1, len(appliedFilters))
+}
+
+func TestGetAppliedFiltersMultipleTaskFilterSelectedReturned(t *testing.T) {
+
+	mockClient := &mocks.MockClient{}
+	client, _ := NewClient(mockClient, "http://localhost:3000")
+
+	apiTaskTypes := []ApiTaskTypes{
+		{
+			Handle:     "CWGN",
+			Incomplete: "Casework - General",
+			Complete:   "Casework - General",
+			User:       true,
+			Category:   "supervision",
+			IsSelected: true,
+		},
+		{
+			Handle:     "ORAL",
+			Incomplete: "Order - Allocate to team",
+			Complete:   "Order - Allocate to team",
+			User:       true,
+			Category:   "supervision",
+			IsSelected: true,
+		},
+	}
+
+	teamCollection := []ReturnedTeamCollection{
+		{
+			Id:             12,
+			Name:           "Lay Team 1 - (Supervision)",
+			Type:           "Supervision",
+			TypeLabel:      "Only",
+			IsTeamSelected: false,
+		},
+		{
+			Id:             13,
+			Name:           "Allocations Team",
+			Type:           "Supervision",
+			TypeLabel:      "Only",
+			IsTeamSelected: false,
+		},
+	}
+
+	assigneeTeam := AssigneesTeam{}
+
+	expectedFilter := []string{
+		"Casework - General",
+		"Order - Allocate to team",
+	}
+
+	appliedFilters := client.GetAppliedFilters(12, apiTaskTypes, teamCollection, assigneeTeam)
+
+	assert.Equal(t, expectedFilter, appliedFilters)
+	assert.Equal(t, 2, len(appliedFilters))
+}
+
+func TestGetAppliedFiltersSingleTaskSingleTeamFilterSelectedReturned(t *testing.T) {
+
+	mockClient := &mocks.MockClient{}
+	client, _ := NewClient(mockClient, "http://localhost:3000")
+
+	apiTaskTypes := []ApiTaskTypes{
+		{
+			Handle:     "CWGN",
+			Incomplete: "Casework - General",
+			Complete:   "Casework - General",
+			User:       true,
+			Category:   "supervision",
+			IsSelected: false,
+		},
+		{
+			Handle:     "ORAL",
+			Incomplete: "Order - Allocate to team",
+			Complete:   "Order - Allocate to team",
+			User:       true,
+			Category:   "supervision",
+			IsSelected: true,
+		},
+	}
+
+	teamCollection := []ReturnedTeamCollection{
+		{
+			Id:             12,
+			Name:           "Supervision Team 1",
+			Type:           "Supervision",
+			TypeLabel:      "Only",
+			IsTeamSelected: false,
+		},
+		{
+			Id:             13,
+			Name:           "Allocations Team",
+			Type:           "Supervision",
+			TypeLabel:      "Only",
+			IsTeamSelected: true,
+		},
+	}
+
+	assigneeTeam := AssigneesTeam{
+		Id:   13,
+		Name: "Lay Team 1 - (Supervision)",
+		Members: []AssigneeTeamMembers{
+			{
+				TeamMembersId:          1,
+				TeamMembersName:        "Test One",
+				TeamMembersDisplayName: "Test One",
+				IsSelected:             false,
+			},
+			{
+				TeamMembersId:          2,
+				TeamMembersName:        "Test Two",
+				TeamMembersDisplayName: "Test Two",
+				IsSelected:             false,
+			},
+		},
+	}
+
+	expectedFilter := []string{
+		"Order - Allocate to team",
+		"Allocations Team",
+	}
+
+	appliedFilters := client.GetAppliedFilters(13, apiTaskTypes, teamCollection, assigneeTeam)
+
+	assert.Equal(t, expectedFilter, appliedFilters)
+	assert.Equal(t, 2, len(appliedFilters))
+}
+
+func TestGetAppliedFiltersSingleTaskSingleTeamSingleTeamMemberFilterSelectedReturned(t *testing.T) {
+
+	mockClient := &mocks.MockClient{}
+	client, _ := NewClient(mockClient, "http://localhost:3000")
+
+	apiTaskTypes := []ApiTaskTypes{
+		{
+			Handle:     "CWGN",
+			Incomplete: "Casework - General",
+			Complete:   "Casework - General",
+			User:       true,
+			Category:   "supervision",
+			IsSelected: false,
+		},
+		{
+			Handle:     "ORAL",
+			Incomplete: "Order - Allocate to team",
+			Complete:   "Order - Allocate to team",
+			User:       true,
+			Category:   "supervision",
+			IsSelected: true,
+		},
+	}
+
+	teamCollection := []ReturnedTeamCollection{
+		{
+			Id:             12,
+			Name:           "Supervision Team 1",
+			Type:           "Supervision",
+			TypeLabel:      "Only",
+			IsTeamSelected: false,
+		},
+		{
+			Id:             13,
+			Name:           "Allocations Team",
+			Type:           "Supervision",
+			TypeLabel:      "Only",
+			IsTeamSelected: true,
+		},
+	}
+
+	assigneeTeam := AssigneesTeam{
+		Id:   13,
+		Name: "Allocations Team",
+		Members: []AssigneeTeamMembers{
+			{
+				TeamMembersId:          1,
+				TeamMembersName:        "Test One",
+				TeamMembersDisplayName: "Test One",
+				IsSelected:             false,
+			},
+			{
+				TeamMembersId:          2,
+				TeamMembersName:        "Test Two",
+				TeamMembersDisplayName: "Test Two",
+				IsSelected:             true,
+			},
+		},
+	}
+
+	expectedFilter := []string{
+		"Order - Allocate to team",
+		"Allocations Team",
+		"Test Two",
+	}
+
+	appliedFilters := client.GetAppliedFilters(13, apiTaskTypes, teamCollection, assigneeTeam)
+
+	assert.Equal(t, expectedFilter, appliedFilters)
+	assert.Equal(t, 3, len(appliedFilters))
+}
+
+func TestGetAppliedFiltersMultipleTasksMultipleTeamsSingleTeamMemberFilterSelectedReturned(t *testing.T) {
+
+	mockClient := &mocks.MockClient{}
+	client, _ := NewClient(mockClient, "http://localhost:3000")
+
+	apiTaskTypes := []ApiTaskTypes{
+		{
+			Handle:     "CWGN",
+			Incomplete: "Casework - General",
+			Complete:   "Casework - General",
+			User:       true,
+			Category:   "supervision",
+			IsSelected: true,
+		},
+		{
+			Handle:     "ORAL",
+			Incomplete: "Order - Allocate to team",
+			Complete:   "Order - Allocate to team",
+			User:       true,
+			Category:   "supervision",
+			IsSelected: true,
+		},
+	}
+
+	teamCollection := []ReturnedTeamCollection{
+		{
+			Id:             12,
+			Name:           "Supervision Team 1",
+			Type:           "Supervision",
+			TypeLabel:      "Only",
+			IsTeamSelected: true,
+		},
+		{
+			Id:             13,
+			Name:           "Allocations Team",
+			Type:           "Supervision",
+			TypeLabel:      "Only",
+			IsTeamSelected: true,
+		},
+	}
+
+	assigneeTeam := AssigneesTeam{
+		Id:   13,
+		Name: "Allocations Team",
+		Members: []AssigneeTeamMembers{
+			{
+				TeamMembersId:          1,
+				TeamMembersName:        "Test One",
+				TeamMembersDisplayName: "Test One",
+				IsSelected:             true,
+			},
+			{
+				TeamMembersId:          2,
+				TeamMembersName:        "Test Two",
+				TeamMembersDisplayName: "Test Two",
+				IsSelected:             false,
+			},
+		},
+	}
+
+	expectedFilter := []string{
+		"Casework - General",
+		"Order - Allocate to team",
+		"Allocations Team",
+		"Test One",
+	}
+
+	appliedFilters := client.GetAppliedFilters(13, apiTaskTypes, teamCollection, assigneeTeam)
+
+	assert.Equal(t, expectedFilter, appliedFilters)
+	assert.Equal(t, 4, len(appliedFilters))
+}
+
+func TestGetAppliedFiltersNoFiltersSelectedReturned(t *testing.T) {
+
+	mockClient := &mocks.MockClient{}
+	client, _ := NewClient(mockClient, "http://localhost:3000")
+
+	apiTaskTypes := []ApiTaskTypes{
+		{
+			Handle:     "CWGN",
+			Incomplete: "Casework - General",
+			Complete:   "Casework - General",
+			User:       true,
+			Category:   "supervision",
+			IsSelected: false,
+		},
+		{
+			Handle:     "ORAL",
+			Incomplete: "Order - Allocate to team",
+			Complete:   "Order - Allocate to team",
+			User:       true,
+			Category:   "supervision",
+			IsSelected: false,
+		},
+	}
+
+	teamCollection := []ReturnedTeamCollection{
+		{
+			Id:             12,
+			Name:           "Supervision Team 1",
+			Type:           "Supervision",
+			TypeLabel:      "Only",
+			IsTeamSelected: false,
+		},
+		{
+			Id:             13,
+			Name:           "Allocations Team",
+			Type:           "Supervision",
+			TypeLabel:      "Only",
+			IsTeamSelected: false,
+		},
+	}
+
+	assigneeTeam := AssigneesTeam{
+		Id:   13,
+		Name: "Allocations Team",
+		Members: []AssigneeTeamMembers{
+			{
+				TeamMembersId:          1,
+				TeamMembersName:        "Test One",
+				TeamMembersDisplayName: "Test One",
+				IsSelected:             false,
+			},
+			{
+				TeamMembersId:          2,
+				TeamMembersName:        "Test Two",
+				TeamMembersDisplayName: "Test Two",
+				IsSelected:             false,
+			},
+		},
+	}
+
+	expectedFilter := []string(nil)
+
+	appliedFilters := client.GetAppliedFilters(13, apiTaskTypes, teamCollection, assigneeTeam)
+
+	assert.Equal(t, expectedFilter, appliedFilters)
+	assert.Equal(t, 0, len(appliedFilters))
+}


### PR DESCRIPTION
This PR is to add unit tests for filtering as well as replacing PACT based unit tests with the newer pattern tests as in the deputy hub. 