### PR TITLE
Remove inline scripts that break under Sirius CSP

### DIFF
--- a/cypress/e2e/team_selection.cy.js
+++ b/cypress/e2e/team_selection.cy.js
@@ -1,16 +1,16 @@
 describe("Team Selection", () => {
-  // beforeEach(() => {
-  //     cy.setCookie("Other", "other");
-  //     cy.setCookie("XSRF-TOKEN", "abcde");
-  //     cy.visit("/supervision/workflow/1");
-  // });
+  beforeEach(() => {
+      cy.setCookie("Other", "other");
+      cy.setCookie("XSRF-TOKEN", "abcde");
+      cy.visit("/supervision/workflow/1");
+  });
 
-//  it("pulls through my team on the change view bar", () => {
-//   cy.get(".moj-team-banner__container > .govuk-form-group > .govuk-select").should('contain', "Lay Team 1 - (Supervision)")
-// })
+ it("pulls through my team on the change view bar", () => {
+  cy.get(".moj-team-banner__container > .govuk-form-group > .govuk-select").should('contain', "Lay Team 1 - (Supervision)")
+})
 
-// it("should show the persons team thats logged in", () => {
-//   cy.get(".moj-team-banner__container").should("contain", "Lay Team 1 - (Supervision)")
-// })
+it("should show the persons team thats logged in", () => {
+  cy.get(".moj-team-banner__container").should("contain", "Lay Team 1 - (Supervision)")
+})
 
 });

--- a/web/assets/javascript/form-controls.js
+++ b/web/assets/javascript/form-controls.js
@@ -1,8 +1,8 @@
 const FormControls = (element) => {
 
-    //event delegation bound to all data-control="select-submit"
+    //event delegation bound to all data-module="app-select-submit"
     document.addEventListener("change", function (e) {
-        if (e.target?.dataset?.control == 'select-submit') {
+        if (e.target?.dataset?.module == 'app-select-submit') {
             e.target.closest('form')?.submit();
         }
     })

--- a/web/assets/javascript/form-controls.js
+++ b/web/assets/javascript/form-controls.js
@@ -1,0 +1,12 @@
+const FormControls = (element) => {
+
+    //event delegation bound to all data-control="select-submit"
+    document.addEventListener("change", function (e) {
+        if (e.target?.dataset?.control == 'select-submit') {
+            e.target.closest('form')?.submit();
+        }
+    })
+
+}
+
+export default FormControls;

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -4,8 +4,14 @@ import MOJFrontend from '@ministryofjustice/frontend/moj/all.js';
 import ManageTasks from './javascript/manage-tasks';
 import ManageFilters from './javascript/manage-filters';
 import MojBannerAutoHide from './javascript/moj-banner-auto-hide';
+import FormControls from './javascript/form-controls';
+
+//moved from inline due to Content Security Policy
+document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 
 GOVUKFrontend.initAll();
+
+FormControls(); 
 
 MojBannerAutoHide(document.querySelector('.app-main-class'));
 

--- a/web/template/layout/page.gotmpl
+++ b/web/template/layout/page.gotmpl
@@ -21,9 +21,6 @@
     </head>
 
     <body class="govuk-template__body sirius-workflow" data-test="My value" data-other="report:details">
-      <script>
-        document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-      </script>
 
       <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 

--- a/web/template/layout/pagination.gotmpl
+++ b/web/template/layout/pagination.gotmpl
@@ -40,7 +40,7 @@
       </ul>
         <div class="govuk-form-group moj-pagination__change-view-number">
           <label class="govuk-label" for="label-display-rows">View</label>
-          <select class="govuk-select" id="display-rows" name="tasksPerPage" aria-labelledby="display-rows" aria-label="display-rows" onchange="this.form.submit()">
+          <select class="govuk-select" id="display-rows" name="tasksPerPage" aria-labelledby="display-rows" aria-label="display-rows" data-control="select-submit">
             <option value="25" id="display-rows_25"{{if eq .PageDetails.StoredTaskLimit 25}}selected{{end}} >25</label></option>
             <option value="50" id="display-rows_50"{{if eq .PageDetails.StoredTaskLimit 50 }}selected{{end}} >50</label></option>
             <option value="100" id="display-rows_100"{{if eq .PageDetails.StoredTaskLimit 100 }}selected{{end}} >100</label></option>

--- a/web/template/layout/pagination.gotmpl
+++ b/web/template/layout/pagination.gotmpl
@@ -40,7 +40,7 @@
       </ul>
         <div class="govuk-form-group moj-pagination__change-view-number">
           <label class="govuk-label" for="label-display-rows">View</label>
-          <select class="govuk-select" id="display-rows" name="tasksPerPage" aria-labelledby="display-rows" aria-label="display-rows" data-control="select-submit">
+          <select class="govuk-select" id="display-rows" name="tasksPerPage" aria-labelledby="display-rows" aria-label="display-rows" data-module="app-select-submit">
             <option value="25" id="display-rows_25"{{if eq .PageDetails.StoredTaskLimit 25}}selected{{end}} >25</label></option>
             <option value="50" id="display-rows_50"{{if eq .PageDetails.StoredTaskLimit 50 }}selected{{end}} >50</label></option>
             <option value="100" id="display-rows_100"{{if eq .PageDetails.StoredTaskLimit 100 }}selected{{end}} >100</label></option>

--- a/web/template/layout/team-selection.gotmpl
+++ b/web/template/layout/team-selection.gotmpl
@@ -9,7 +9,7 @@
       <label class="govuk-label" for="change-team">
         Change view
       </label>
-      <select class="govuk-select ignore-pagination-bottom" label for="pagination-selected-team" name="change-team" onchange="window.location.replace('/supervision/workflow/?change-team=' + this.value)">
+      <select class="govuk-select ignore-pagination-bottom" for="pagination-selected-team" data-control="select-submit" name="change-team">
         {{ range .TeamSelection }}
           <option value="{{ .Id }}" id="pagination-selected-team" name="change-team-option" label="{{ .Name }}" {{if eq .Id .UserSelectedTeam}}selected{{end}}>{{ .Name }}</option>
         {{ end }}

--- a/web/template/layout/team-selection.gotmpl
+++ b/web/template/layout/team-selection.gotmpl
@@ -9,7 +9,7 @@
       <label class="govuk-label" for="change-team">
         Change view
       </label>
-      <select class="govuk-select ignore-pagination-bottom" for="pagination-selected-team" data-control="select-submit" name="change-team">
+      <select class="govuk-select ignore-pagination-bottom" for="pagination-selected-team" data-module="app-select-submit" name="change-team">
         {{ range .TeamSelection }}
           <option value="{{ .Id }}" id="pagination-selected-team" name="change-team-option" label="{{ .Name }}" {{if eq .Id .UserSelectedTeam}}selected{{end}}>{{ .Name }}</option>
         {{ end }}


### PR DESCRIPTION
Fixes issues where inline onchange event handlers weren't activating due to the Sirius content security policy blocking inline scripts.

Move form controls to delegated event pattern.

Uncomment tests.

Fixes SW-5719