### PR TITLE
Stop logging context.Canceled as errors

### DIFF
--- a/internal/server/wrap_handler.go
+++ b/internal/server/wrap_handler.go
@@ -1,11 +1,14 @@
 package server
 
 import (
+	"context"
+	"errors"
 	"fmt"
-	"github.com/ministryofjustice/opg-sirius-workflow/internal/sirius"
-	"go.uber.org/zap"
 	"net/http"
 	"time"
+
+	"github.com/ministryofjustice/opg-sirius-workflow/internal/sirius"
+	"go.uber.org/zap"
 )
 
 type ErrorVars struct {
@@ -56,6 +59,11 @@ func wrapHandler(client ApiClient, logger *zap.SugaredLogger, tmplError Template
 			)
 
 			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					w.WriteHeader(499)
+					return
+				}
+
 				if err == sirius.ErrUnauthorized {
 					http.Redirect(w, r, envVars.SiriusURL+"/auth", http.StatusFound)
 					return

--- a/internal/sirius/api_client.go
+++ b/internal/sirius/api_client.go
@@ -2,6 +2,7 @@ package sirius
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -115,7 +116,7 @@ func (c *ApiClient) logResponse(req *http.Request, resp *http.Response, err erro
 		response = strconv.Itoa(resp.StatusCode)
 	}
 	c.logger.Info("method: " + req.Method + ", url: " + req.URL.Path + ", response: " + response)
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		c.logger.Error(err.Error())
 	}
 }


### PR DESCRIPTION
It's common for the upstream cancels the request before API requests finish (e.g. if the user closes the tab or navigates away) and we don't need to log it as an error.

Skipping these will reduce the amount of false positive errors in production logs.

Fixes CTC-174 #minor